### PR TITLE
Добавил выбор правильной версии для прогона тестов на Teamcity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-﻿.idea
+.idea
 bin
 Backup
 obj
 *.DotSettings
+*.DotSettings.user
+*.orig

--- a/VacationTests/DiExample/DiExample.csproj
+++ b/VacationTests/DiExample/DiExample.csproj
@@ -7,6 +7,19 @@
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 
+    <Choose>
+        <When Condition="$(TEAMCITY_VERSION)!=''">
+            <ItemGroup>
+                <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.5200" />
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup>
+                <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="*" />
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
@@ -16,6 +29,5 @@
         <PackageReference Include="NUnitLite" Version="3.13.3" />
         <PackageReference Include="coverlet.collector" Version="3.0.2" />
         <PackageReference Include="Selenium.WebDriver" Version="4.8.0" />
-        <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="113.0.5672.6300" />
     </ItemGroup>
 </Project>

--- a/VacationTests/VacationTests/Tests/EmployeePage/AverageDailyEarningsCalculatorTests.cs
+++ b/VacationTests/VacationTests/Tests/EmployeePage/AverageDailyEarningsCalculatorTests.cs
@@ -13,7 +13,7 @@ namespace VacationTests.Tests.EmployeePage
         public void SmokyTest()
         {
             var page = Navigation
-                .OpenPage<PageBase>(@"https://ronzhina.gitlab-pages.kontur.host/for-course/#/user/1")
+                .OpenPage<PageBase>(@"https://test-automation-course.gitlab-pages.kontur.host/for-course/#/user/1")
                 .WrappedDriver;
 
             Thread.Sleep(2000);

--- a/VacationTests/VacationTests/VacationTests.csproj
+++ b/VacationTests/VacationTests/VacationTests.csproj
@@ -8,6 +8,19 @@
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 
+  <Choose>
+    <When Condition="$(TEAMCITY_VERSION)!=''">
+      <ItemGroup>
+        <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.5200" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="*" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
@@ -19,6 +32,5 @@
     <PackageReference Include="Selenium.WebDriver" Version="4.8.1" />
     <PackageReference Include="Kontur.RetryableAssertions" Version="1.0.0" />
     <PackageReference Include="Kontur.Selone" Version="1.0.0-alpha" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="112.0.5615.4900" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Локально используется всегда самая новая версия. Если вдруг версия пакета убежал вперед, то придется обновить Chrome.
На агентах стоит 105, поэтому используется соответствующая версия ChromeDriver.